### PR TITLE
Using `#define_method` for fewer surprises

### DIFF
--- a/lib/imperator/command.rb
+++ b/lib/imperator/command.rb
@@ -15,7 +15,7 @@ class Imperator::Command
   end
 
   def self.action(&block)
-    define_method(:raw_perform, &block)
+    define_method(:action, &block)
   end
 
   alias_method :params, :attributes
@@ -62,12 +62,12 @@ class Imperator::Command
   end
 
   # @abstract
-  def raw_perform
-    raise "You need to define the perform block for #{self.class.name}"
+  def action
+    raise NoMethodError.new("Please define #action for #{self.class.name}")
   end
 
   def perform
-    run_callbacks(:perform) { raw_perform }
+    run_callbacks(:perform) { action }
   end
 
   def method_missing(method, *args)


### PR DESCRIPTION
Hi there!

This patch uses `#define_method` under the covers, so that actions are inheritable as methods.  It's possible that it performs faster, but honestly I just like the way the code looks a little better :).  Up to you.

Cheers,
--Jay
