### PR TITLE
Migrate from UUIDTools to UUID

### DIFF
--- a/imperator.gemspec
+++ b/imperator.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   # specify any dependencies here; for example:
   s.add_development_dependency "rspec"
   # s.add_runtime_dependency "rest-client"
-  s.add_runtime_dependency "uuidtools"
+  s.add_runtime_dependency "uuid"
   s.add_runtime_dependency "activemodel"
   s.add_runtime_dependency "virtus"
 end

--- a/lib/imperator/command.rb
+++ b/lib/imperator/command.rb
@@ -1,4 +1,4 @@
-require 'uuidtools'
+require 'uuid'
 require 'active_model'
 require 'virtus'
 class Imperator::Command
@@ -16,7 +16,7 @@ class Imperator::Command
 
   define_model_callbacks :create, :perform, :initialize
 
-  attribute :id, String, :default => proc { UUIDTools::UUID.timestamp_create.to_s }
+  attribute :id, String, :default => proc { UUID.generate }
 
   def self.action(&block)
     define_method(:action, &block)


### PR DESCRIPTION
doesn't produce the rbconfig warning in Ruby 1.9.3.
