### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#Imperator
+# Imperator
 Imperator is a small gem to help with command objects. The [command pattern](http://c2.com/cgi/wiki?CommandPattern) is a design pattern used to encapsulate all of the information needed to execute a method or process at a point in time. In a web application, commands are typically used to delay execution of a method from the request cycle to a background processor.
 
-###Why use commands?
+### Why use commands?
 The problem with controllers in Rails is that they're a part of the web domain—their job is to respond to requests, and ONLY to respond to requests. Anything that happens between the receipt of a request and sending a response is Somebody Else's Job™. Commands are that Somebody Else™. Commands are also very commonly utilized to put work into the background. 
 
 Why are commands an appropriate place to handle that logic? Commands give you the opportunity to encapsulate all of the logic required for an interaction in one spot. Sometimes that interaction is as simple as a method call—more often there are several method calls involved, not all of which deal with domain logic (and thus, are inappropriate for inclusion on the models). Commands give you a place to bring all of these together in one spot without increasing coupling in your controllers or models.
 
 Commands can also be regarded as the contexts from DCI.
 
-###Validation 
+### Validation 
 Commands also give you an appropriate place to handle interaction validation. Validation is most often regarded as a responsibility of the data model. This is a poor fit, because the idea of what's valid for data is very temporally tied to the understanding of the business domain at the time the data was created. Data that's valid today may well be invalid tomorrow, and when that happens you're going to run into a situation where your ActiveRecord models will refuse to work with old data that is no longer valid. Commands don't absolve you of the need to migrate your data when business requirements change, but they do let you move validation to the interaction where it belongs.
 
 Commands can also be used on forms in place of ActiveRecord models, when
@@ -18,23 +18,23 @@ ActiveRecord/ActiveModel/ActiveSupport, but readily supports most of the
 AM interfaces like validations.  These are trivial to include so support
 is not built into Imperator intentionally.
 
-###TODO
+### TODO
 * test coverage—Imperator was extracted out of some other work, and coverage was a part of those test suites.
 * Ensure compatibility with DJ, Resque and Sidekiq
 
-#Using Imperator
+# Using Imperator
 
-##Requirements:
+## Requirements:
 * Virtus (https://github.com/solnic/virtus)
 
-##Installation
+## Installation
  In your Gemfile:
 ```ruby
 gem 'imperator'
 ```
-##Usage
+## Usage
 
-###Creating the command:
+### Creating the command:
 ```ruby
     class DoSomethingCommand < Imperator::Command
       include ActiveModel::Validations
@@ -50,7 +50,7 @@ gem 'imperator'
       end
     end
 ```
-###Using a command on a form builder
+### Using a command on a form builder
 First, you'll need to make your commands adhere to ActiveModel's naming
 interface:
 
@@ -73,7 +73,7 @@ Then you can use them on a form just as you would a model:
     ...
     <% end %>
 ```
-###Using a command
+### Using a command
 ```ruby
     class SomeController < ApplicationController
       def update
@@ -87,11 +87,11 @@ Then you can use them on a form just as you would a model:
       end
     end
 ```
-###Using a command in the background (Delayed::Job)
+### Using a command in the background (Delayed::Job)
 ```ruby
     Delayed::Job.enqueue command
 ```
-###Using a background processor
+### Using a background processor
 You can create a custom background processor very easily. It merely
 needs to implement the class method `#commit`
 ```ruby
@@ -115,7 +115,7 @@ command or instance
     command.commit(:queue => "low")
 ```
 
-###Contributors
+### Contributors
 Many thanks to the following contributors for bugfixes, testing, and
 additional functionality
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
